### PR TITLE
added TermsLookup

### DIFF
--- a/src/main/kotlin/mbuhot/eskotlin/query/term/TermsLookup.kt
+++ b/src/main/kotlin/mbuhot/eskotlin/query/term/TermsLookup.kt
@@ -1,0 +1,22 @@
+package mbuhot.eskotlin.query.term
+
+import mbuhot.eskotlin.query.*
+import org.elasticsearch.index.query.*
+import org.elasticsearch.indices.*
+
+class TermsLookupBlock {
+    class TermsData(
+            var name: String,
+            var lookup: TermsLookup) : QueryData()
+
+    infix fun String.to(lookup: TermsLookup): TermsData {
+        return TermsData(name = this, lookup = lookup)
+    }
+}
+
+fun termsLookup(init: TermsLookupBlock.() -> TermsLookupBlock.TermsData): TermsQueryBuilder {
+    val params = TermsLookupBlock().init()
+    return TermsQueryBuilder(params.name, params.lookup).apply {
+        initQuery(params)
+    }
+}

--- a/src/test/kotlin/mbuhot/eskotlin/query/term/TermsLookupTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/term/TermsLookupTest.kt
@@ -1,0 +1,30 @@
+package mbuhot.eskotlin.query.term
+
+import mbuhot.eskotlin.query.*
+import org.elasticsearch.indices.*
+import org.junit.*
+
+class TermsLookupTest {
+
+    @Test
+    fun `test terms lookup`() {
+        val query = termsLookup {
+            "user" to TermsLookup("users", "user", "2", "followers")
+        }
+
+        query should_render_as """
+            {
+                "terms" : {
+                    "user" : {
+                        "index" : "users",
+                        "type" : "user",
+                        "id" : "2",
+                        "path" : "followers"
+                    },
+                    "boost": 1.0
+                }
+            }
+            """
+    }
+
+}


### PR DESCRIPTION
Unless I overlooked something, eskotlin currently does not support terms lookup, as described here:
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/query-dsl-terms-query.html#query-dsl-terms-lookup

I added it. 

