### PR TITLE
Adding the ability to accept multiple must/should clauses for bool query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ val query = bool {
             }
         }
     }
-    should = listOf(
-        term { "tag" to "wow" },
-        term { "tag" to "elasticsearch" })
+    should {
+        term { "tag" to "wow" }
+        term { "tag" to "elasticsearch" }
+    }
     minimum_should_match = 1
     boost = 1.0f
 }

--- a/src/main/kotlin/mbuhot/eskotlin/query/ListQueriesBlock.kt
+++ b/src/main/kotlin/mbuhot/eskotlin/query/ListQueriesBlock.kt
@@ -1,0 +1,113 @@
+package mbuhot.eskotlin.query
+
+import mbuhot.eskotlin.query.compound.*
+import mbuhot.eskotlin.query.fulltext.*
+import mbuhot.eskotlin.query.joining.HasChildData
+import mbuhot.eskotlin.query.joining.HasParentData
+import mbuhot.eskotlin.query.joining.NestedData
+import mbuhot.eskotlin.query.term.*
+import org.elasticsearch.index.query.MatchAllQueryBuilder
+import org.elasticsearch.index.query.QueryBuilder
+
+/**
+ * Created by vince(me@liuwj.me) on Apr 21, 2018.
+ */
+class ListQueriesBlock {
+    val queries = ArrayList<QueryBuilder>()
+
+    fun bool(init: BoolData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.compound.bool(init)
+    }
+
+    fun boosting(init: BoostingData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.compound.boosting(init)
+    }
+
+    fun constant_score(init: ConstantScoreData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.compound.constant_score(init)
+    }
+
+    fun dis_max(init: DisMaxData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.compound.dis_max(init)
+    }
+
+    fun function_score(init: FunctionScoreData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.compound.function_score(init)
+    }
+
+    fun common(init: CommonBlock.() -> CommonBlock.CommonData) {
+        queries += mbuhot.eskotlin.query.fulltext.common(init)
+    }
+
+    fun match(init: MatchBlock.() -> MatchBlock.MatchData) {
+        queries += mbuhot.eskotlin.query.fulltext.match(init)
+    }
+
+    fun match_phrase(init: MatchPhraseBlock.() -> MatchPhraseBlock.MatchPhraseData) {
+        queries += mbuhot.eskotlin.query.fulltext.match_phrase(init)
+    }
+
+    fun match_phrase_prefix(init: MatchPhrasePrefixBlock.() -> MatchPhrasePrefixBlock.MatchPhrasePrefixData) {
+        queries += mbuhot.eskotlin.query.fulltext.match_phrase_prefix(init)
+    }
+
+    fun multi_match(init: MultiMatchData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.fulltext.multi_match(init)
+    }
+
+    fun has_child(init: HasChildData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.joining.has_child(init)
+    }
+
+    fun has_parent(init: HasParentData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.joining.has_parent(init)
+    }
+
+    fun nested(init: NestedData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.joining.nested(init)
+    }
+
+    fun exists(init: ExistsData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.term.exists(init)
+    }
+
+    fun fuzzy(init: FuzzyBlock.() -> FuzzyBlock.FuzzyData) {
+        queries += mbuhot.eskotlin.query.term.fuzzy(init)
+    }
+
+    fun ids(init: IdsData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.term.ids(init)
+    }
+
+    fun match_all(init: MatchAllQueryBuilder.() -> Unit) {
+        queries += mbuhot.eskotlin.query.term.match_all(init)
+    }
+
+    fun prefix(init: PrefixBlock.() -> PrefixBlock.PrefixData) {
+        queries += mbuhot.eskotlin.query.term.prefix(init)
+    }
+
+    fun range(init: RangeBlock.() -> RangeBlock.RangeData) {
+        queries += mbuhot.eskotlin.query.term.range(init)
+    }
+
+    fun regexp(init: RegexpBlock.() -> RegexpBlock.RegexpData) {
+        queries += mbuhot.eskotlin.query.term.regexp(init)
+    }
+
+    fun term(init: TermBlock.() -> TermBlock.TermData) {
+        queries += mbuhot.eskotlin.query.term.term(init)
+    }
+
+    fun terms(init: TermsBlock.() -> TermsBlock.TermsData) {
+        queries += mbuhot.eskotlin.query.term.terms(init)
+    }
+
+    fun type(init: TypeData.() -> Unit) {
+        queries += mbuhot.eskotlin.query.term.type(init)
+    }
+
+    fun wildcard(init: WildcardBlock.() -> WildcardBlock.WildcardData) {
+        queries += mbuhot.eskotlin.query.term.wildcard(init)
+    }
+}

--- a/src/main/kotlin/mbuhot/eskotlin/query/compound/Bool.kt
+++ b/src/main/kotlin/mbuhot/eskotlin/query/compound/Bool.kt
@@ -4,6 +4,7 @@
 
 package mbuhot.eskotlin.query.compound
 
+import mbuhot.eskotlin.query.ListQueriesBlock
 import org.elasticsearch.index.query.BoolQueryBuilder
 import org.elasticsearch.index.query.QueryBuilder
 
@@ -16,20 +17,20 @@ data class BoolData(
     var minimum_should_match: Int? = null,
     var boost: Float? = null) {
 
-    fun must(f: () -> QueryBuilder) {
-        must = listOf(f())
+    fun must(init: ListQueriesBlock.() -> Unit) {
+        must = ListQueriesBlock().apply(init).queries
     }
 
-    fun must_not(f: () -> QueryBuilder) {
-        must_not = listOf(f())
+    fun must_not(init: ListQueriesBlock.() -> Unit) {
+        must_not = ListQueriesBlock().apply(init).queries
     }
 
-    fun filter(f: () -> QueryBuilder) {
-        filter = listOf(f())
+    fun filter(init: ListQueriesBlock.() -> Unit) {
+        filter = ListQueriesBlock().apply(init).queries
     }
 
-    fun should(f: () -> QueryBuilder) {
-        should = listOf(f())
+    fun should(init: ListQueriesBlock.() -> Unit) {
+        should = ListQueriesBlock().apply(init).queries
     }
 }
 

--- a/src/main/kotlin/mbuhot/eskotlin/query/compound/DisMax.kt
+++ b/src/main/kotlin/mbuhot/eskotlin/query/compound/DisMax.kt
@@ -4,13 +4,19 @@
 
 package mbuhot.eskotlin.query.compound
 
+import mbuhot.eskotlin.query.ListQueriesBlock
 import org.elasticsearch.index.query.DisMaxQueryBuilder
 import org.elasticsearch.index.query.QueryBuilder
 
 data class DisMaxData(
     var tie_breaker: Float? = null,
     var boost: Float? = null,
-    var queries: List<QueryBuilder>? = null)
+    var queries: List<QueryBuilder>? = null) {
+
+    fun queries(init: ListQueriesBlock.() -> Unit) {
+        queries = ListQueriesBlock().apply(init).queries
+    }
+}
 
 fun dis_max(init: DisMaxData.() -> Unit): DisMaxQueryBuilder {
     val params = DisMaxData().apply(init)

--- a/src/test/kotlin/mbuhot/eskotlin/query/compound/DisMaxTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/compound/DisMaxTest.kt
@@ -5,7 +5,6 @@
 package mbuhot.eskotlin.query.compound
 
 import mbuhot.eskotlin.query.should_render_as
-import mbuhot.eskotlin.query.term.term
 import org.junit.Test
 
 /**
@@ -20,10 +19,10 @@ class DisMaxTest {
         val query = dis_max {
             tie_breaker = 0.7f
             boost = 1.2f
-            queries = listOf(
-                term { "age" to "34" },
+            queries {
+                term { "age" to "34" }
                 term { "age" to "35" }
-            )
+            }
         }
 
         query should_render_as """

--- a/src/test/kotlin/mbuhot/eskotlin/query/joining/NestedTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/joining/NestedTest.kt
@@ -25,10 +25,10 @@ class NestedTest {
             score_mode = ScoreMode.Avg
             query {
                 bool {
-                    must = listOf(
-                            match { "obj1.name" to "blue" },
-                            range { "obj1.count" { gt = 5 } }
-                    )
+                    must {
+                        match { "obj1.name" to "blue" }
+                        range { "obj1.count" { gt = 5 } }
+                    }
                 }
             }
         }


### PR DESCRIPTION
We wrote a bool query with multiple clauses like this before: 
```kotlin
val query = bool {
    should = listOf(
        term { "tag" to "wow" },
        term { "tag" to "elasticsearch" }
    )
}
```

I implemented a better syntax: 
```kotlin
val query = bool {
    should {
        term { "tag" to "wow" }
        term { "tag" to "elasticsearch" }
    }
}
```

The new syntax is compatible with the previous one which only accepts a single clause in source code level.

Please check `ListQueriesBlock.kt`, `Bool.kt` and `BoolTest.kt`. 