### PR TITLE
Upgrade dependencies + bump version to 0.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
  */
 
 group 'mbuhot'
-version '0.7.0'
+version '0.8.0'
 
 apply plugin: 'kotlin'
 apply plugin: 'com.jfrog.bintray'
@@ -15,19 +15,19 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.60"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.+'
     }
 }
 
 dependencies {
-    compile "org.elasticsearch:elasticsearch:6.3.2"
-    compile "org.elasticsearch.plugin:parent-join-client:6.3.2"
-    compile "org.jetbrains.kotlin:kotlin-stdlib:1.2.60"
-    testCompile "org.apache.logging.log4j:log4j-api:2.6.2"
-    testCompile "org.apache.logging.log4j:log4j-core:2.6.2"
-    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.7.2'
-    testCompile "junit:junit:4.11"
+    compile "org.elasticsearch:elasticsearch:7.5.1"
+    compile "org.elasticsearch.plugin:parent-join-client:7.5.1"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:1.3.61"
+    testCompile "org.apache.logging.log4j:log4j-api:2.13.0"
+    testCompile "org.apache.logging.log4j:log4j-core:2.13.0"
+    testCompile 'com.fasterxml.jackson.core:jackson-databind:2.10.2'
+    testCompile "junit:junit:4.13"
 }
 
 repositories {

--- a/src/main/kotlin/mbuhot/eskotlin/query/term/Fuzzy.kt
+++ b/src/main/kotlin/mbuhot/eskotlin/query/term/Fuzzy.kt
@@ -15,7 +15,8 @@ class FuzzyBlock {
             var value: Any? = null,
             var fuzziness: Fuzziness? = null,
             var prefix_length: Int? = null,
-            var max_expansions: Int? = null) : QueryData()
+            var max_expansions: Int? = null,
+            var transpositions: Boolean? = null) : QueryData()
 
     infix fun String.to(value: Any) = FuzzyData(name = this, value = value)
 
@@ -33,6 +34,7 @@ fun fuzzy(init: FuzzyBlock.() -> FuzzyBlock.FuzzyData): FuzzyQueryBuilder {
         params.fuzziness?.let { fuzziness(it) }
         params.prefix_length?.let { prefixLength(it) }
         params.max_expansions?.let { maxExpansions(it) }
+        transpositions(params.transpositions ?: false)
     }
 }
 

--- a/src/main/kotlin/mbuhot/eskotlin/query/term/Ids.kt
+++ b/src/main/kotlin/mbuhot/eskotlin/query/term/Ids.kt
@@ -25,6 +25,5 @@ fun ids(init: IdsData.() -> Unit): IdsQueryBuilder {
     return IdsQueryBuilder().apply {
         initQuery(params)
         addIds(*params.values.toTypedArray())
-        types(*params.types.toTypedArray())
     }
 }

--- a/src/test/kotlin/mbuhot/eskotlin/query/Util.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/Util.kt
@@ -4,16 +4,13 @@
 package mbuhot.eskotlin.query
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import org.hamcrest.CoreMatchers.equalTo
-import org.junit.Assert.assertThat
+import org.junit.Assert.assertEquals
 
 
 val jsonMapper = ObjectMapper()
 fun json_normalize(str: String) : String = jsonMapper.readTree(str).let { jsonMapper.writeValueAsString(it) }
 
 infix fun <T> T.should_render_as(jsonStr: String) {
-    assertThat(
-        json_normalize(this.toString()),
-        equalTo(json_normalize(jsonStr)))
+    assertEquals(json_normalize(this.toString()), json_normalize(jsonStr))
 }
 

--- a/src/test/kotlin/mbuhot/eskotlin/query/joining/HasChildTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/joining/HasChildTest.kt
@@ -53,6 +53,7 @@ class HasChildTest {
                     "from": 0,
                     "size": 3,
                     "version": false,
+                    "seq_no_primary_term": false,
                     "explain": false,
                     "track_scores": false
                 }

--- a/src/test/kotlin/mbuhot/eskotlin/query/joining/HasParentTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/joining/HasParentTest.kt
@@ -49,6 +49,7 @@ class HasParentTest {
                     "from": 0,
                     "size": 3,
                     "version": false,
+                    "seq_no_primary_term": false,
                     "explain": false,
                     "track_scores": false
                 }

--- a/src/test/kotlin/mbuhot/eskotlin/query/term/IdsTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/term/IdsTest.kt
@@ -22,43 +22,6 @@ class IdsTest {
         query should_render_as """
         {
             "ids" : {
-                "type" : [],
-                "values" : ["1", "100", "4"],
-                "boost": 1.0
-            }
-        }
-        """
-    }
-
-    @Test
-    fun `test ids with type`() {
-        val query = ids {
-            type = "my_type"
-            values = listOf("1", "100", "4")
-        }
-
-        query should_render_as """
-        {
-            "ids" : {
-                "type" : ["my_type"],
-                "values" : ["1", "100", "4"],
-                "boost": 1.0
-            }
-        }
-        """
-    }
-
-    @Test
-    fun `test ids with multiple types`() {
-        val query = ids {
-            types = listOf("my_type", "other_type")
-            values = listOf("1", "100", "4")
-        }
-
-        query should_render_as """
-        {
-            "ids" : {
-                "type" : ["my_type", "other_type"],
                 "values" : ["1", "100", "4"],
                 "boost": 1.0
             }


### PR DESCRIPTION
Add support to Elasticsearch 7.5.1 (latest), also upgrade dependencies:
* Elasticsearch: 7.5.1
* Kotlin: 1.3.61
* Log4J: 2.13.0
* Jackson: 2.10.1
* Junit: 4.13