### PR TITLE
Add top level field_value_function support

### DIFF
--- a/src/test/kotlin/mbuhot/eskotlin/query/compound/FunctionScoreTest.kt
+++ b/src/test/kotlin/mbuhot/eskotlin/query/compound/FunctionScoreTest.kt
@@ -7,6 +7,7 @@ package mbuhot.eskotlin.query.compound
 import mbuhot.eskotlin.query.should_render_as
 import mbuhot.eskotlin.query.term.match_all
 import mbuhot.eskotlin.query.term.term
+import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.*
 import org.junit.Test
 
@@ -88,6 +89,49 @@ class FunctionScoreTest {
                 "boost": 1.2
             }
         }
+        """
+    }
+
+    @Test
+    fun `test field_value_factor`() {
+        val query = function_score {
+            query = match_all { }
+            field_value_factor = fieldValueFactorFunction("someField")
+            boost = 1.2f
+            boost_mode = "multiply"
+            score_mode = "max"
+            max_boost = 5.0f
+            min_score = 0.001f
+        }
+        
+        query should_render_as """{
+              "function_score" : {
+                "query" : {
+                  "match_all" : {
+                    "boost" : 1.0
+                  }
+                },
+                "functions" : [
+                  {
+                    "filter" : {
+                      "match_all" : {
+                        "boost" : 1.0
+                      }
+                    },
+                    "field_value_factor" : {
+                      "field" : "someField",
+                      "factor" : 1.0,
+                      "modifier" : "none"
+                    }
+                  }
+                ],
+                "score_mode" : "max",
+                "boost_mode" : "multiply",
+                "max_boost" : 5.0,
+                "min_score" : 0.001,
+                "boost" : 1.2
+              }
+            }
         """
     }
 }


### PR DESCRIPTION
Elasticsearch supports a top-level parameter called "field_value_factor" that
manipulates the score based on a function and a property within the document.

This change brings that same top-level support to the DSL to make it easier 
to discover, since the value is not frequently used within the functions array 
(although it is supported).